### PR TITLE
Support custom representations

### DIFF
--- a/src/MakingSense.AspNet.HypermediaApi/Model/CustomRepresentationModel.cs
+++ b/src/MakingSense.AspNet.HypermediaApi/Model/CustomRepresentationModel.cs
@@ -1,0 +1,66 @@
+﻿using MakingSense.AspNet.HypermediaApi.Linking;
+using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Mvc;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MakingSense.AspNet.HypermediaApi.Model
+{
+	/// <summary>
+	/// Represents models with custom representation.
+	/// </summary>
+	/// <remarks>
+	/// It is required to register CustomRepresentationModelBinder on MVC options.
+	/// </remarks>
+	public abstract class CustomRepresentationModel : BaseModel, ICustomRepresentationModel
+	{
+		public abstract string ContentType { get; }
+
+		public virtual string[] AlternativeContentTypes => null;
+
+		public virtual bool AcceptEmptyContentType => true;
+
+		public virtual bool CanRead(HttpContext context)
+		{
+			var requestContentType = context.Request.ContentType;
+			if (string.IsNullOrEmpty(requestContentType))
+			{
+				return AcceptEmptyContentType;
+			}
+			else
+			{
+				// TODO: improve it based on ASP.NET code after RC2 see https://github.com/aspnet/Mvc/issues/3138
+				return (ContentType != null && requestContentType.IndexOf(ContentType, StringComparison.OrdinalIgnoreCase) >= 0)
+				|| (AlternativeContentTypes != null && AlternativeContentTypes.Any(x => requestContentType.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0));
+			}
+		}
+
+		public async Task ExecuteResultAsync(ActionContext context)
+		{
+			context.HttpContext.Response.OnStarting(() => {
+				SetResponseLinks(context.HttpContext.Response);
+				SetResponseContentType(context.HttpContext.Response);
+				return Task.FromResult(0);
+			});
+
+			await WriteContentAsync(context.HttpContext.Response);
+		}
+
+		protected virtual void SetResponseContentType(HttpResponse response) =>
+			response.ContentType = ContentType;
+
+		protected virtual string FormatLinkHeader(Link link) => string.IsNullOrEmpty(link.Description)
+			? $"<{ link.Href }>; rel=\"{ link.Relation.RelationName }\""
+			: $"<{ link.Href }>; rel=\"{ link.Relation.RelationName }\"; title=\"{ link.Description }\"";
+
+		protected virtual void SetResponseLinks(HttpResponse response) =>
+			response.Headers.AppendCommaSeparatedValues("Link", _links.Select(FormatLinkHeader).ToArray());
+
+		protected abstract Task WriteContentAsync(HttpResponse response);
+
+		public abstract Task SetContentAsync(Stream stream);
+	}
+}

--- a/src/MakingSense.AspNet.HypermediaApi/Model/ICustomRepresentationModel.cs
+++ b/src/MakingSense.AspNet.HypermediaApi/Model/ICustomRepresentationModel.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Mvc;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MakingSense.AspNet.HypermediaApi.Model
+{
+	/// <summary>
+	/// Represents models with custom representation.
+	/// </summary>
+	/// <remarks>
+	/// It is required to register CustomRepresentationModelBinder on MVC options.
+	/// `IActionResult.ExecuteResultAsync()` implementation is used to generate HTTP response.
+	/// `CanRead` and `SetContentAsync()` implementations are used to parse HTTP request.
+	/// </remarks>
+	public interface ICustomRepresentationModel : IActionResult
+	{
+		Task SetContentAsync(Stream stream);
+		bool CanRead(HttpContext context);
+	}
+}

--- a/src/MakingSense.AspNet.HypermediaApi/ModelBinding/CustomRepresentationModelBinder.cs
+++ b/src/MakingSense.AspNet.HypermediaApi/ModelBinding/CustomRepresentationModelBinder.cs
@@ -1,0 +1,57 @@
+using MakingSense.AspNet.HypermediaApi.Model;
+using Microsoft.AspNet.Mvc.ModelBinding;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace MakingSense.AspNet.HypermediaApi.ModelBinding
+{
+	/// <summary>
+	/// Capture binding of ICustomRepresentation models and use a proper binding mechanism
+	/// </summary>
+	public class CustomRepresentationModelBinder : IModelBinder
+	{
+		public async Task<ModelBindingResult> BindModelAsync(ModelBindingContext bindingContext)
+		{
+			if (!bindingContext.IsTopLevelObject || !typeof(ICustomRepresentationModel).GetTypeInfo().IsAssignableFrom(bindingContext.ModelType.GetTypeInfo()))
+			{
+				// Binding Sources are opt-in. This model either didn't specify one or specified something
+				// incompatible so let other binders run.
+				return null;
+			}
+
+			var httpContext = bindingContext.OperationBindingContext.HttpContext;
+			var model = (ICustomRepresentationModel)Activator.CreateInstance(bindingContext.ModelType);
+			var modelBindingKey = bindingContext.ModelName;
+
+			if (!model.CanRead(httpContext))
+			{
+				// TODO: Consider to add reference to Model documentation
+				bindingContext.ModelState.AddModelError(modelBindingKey, "Imposible to parse request body, verify Content-Type header.");
+
+				// This model binder is the only handler for ICustomRepresentationModel binding source and it cannot run
+				// twice. Always tell the model binding system to skip other model binders and never to fall back i.e.
+				// indicate a fatal error.
+				return new ModelBindingResult(modelBindingKey);
+			}
+
+			await model.SetContentAsync(httpContext.Request.Body);
+
+			var valueProviderResult = new ValueProviderResult(rawValue: model);
+			bindingContext.ModelState.SetModelValue(modelBindingKey, valueProviderResult);
+			var validationNode = new ModelValidationNode(modelBindingKey, bindingContext.ModelMetadata, model)
+			{
+				ValidateAllProperties = true
+			};
+
+			return new ModelBindingResult(
+				model,
+				key: modelBindingKey,
+				isModelSet: true,
+				validationNode: validationNode);
+		}
+	}
+}


### PR DESCRIPTION
Hi @abriscioli, @afantini, @pbarrios and @easla,

It adds a nice feature to _MakingSense ASP.NET Hypermedia API_, basically it supports to have models with custom _HTTP Request parsing_ and _HTTP Response serialization_ without loosing support of _linking_ (because it is in header) and neither _custom validations_.

It is useful right now for represent `CampaignContent` (HTML), and in the future for images and other files.

Could you review?