### PR TITLE
Allow to set expiration time to cached queries

### DIFF
--- a/src/MakingSense.AspNet.HypermediaApi/Utilities/CurrentTimeProvider.cs
+++ b/src/MakingSense.AspNet.HypermediaApi/Utilities/CurrentTimeProvider.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MakingSense.AspNet.HypermediaApi.Utilities
+{
+	public interface ICurrentTimeProvider
+	{
+		DateTimeOffset GetCurrent();
+	}
+
+	public class CurrentTimeProvider : ICurrentTimeProvider
+	{
+		public virtual DateTimeOffset GetCurrent() => DateTimeOffset.Now;
+	}
+}
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+	public static class CurrentTimeProviderServiceCollectionExtensions
+	{
+		/// <summary>
+		/// Register default instance of ICurrentTimeProvider to generate current DateTimeOffset values
+		/// </summary>
+		/// <param name="services"></param>
+		/// <returns></returns>
+		public static IServiceCollection AddCurrentTimeProvider([Framework.Internal.NotNull] this IServiceCollection services)
+		{
+			return services.AddSingleton<MakingSense.AspNet.HypermediaApi.Utilities.ICurrentTimeProvider>(x =>
+				new MakingSense.AspNet.HypermediaApi.Utilities.CurrentTimeProvider());
+		}
+	}
+}

--- a/src/MakingSense.AspNet.HypermediaApi/Utilities/QueryTaskCache.cs
+++ b/src/MakingSense.AspNet.HypermediaApi/Utilities/QueryTaskCache.cs
@@ -7,18 +7,33 @@ namespace MakingSense.AspNet.HypermediaApi.Utilities
 {
 	public class QueryTasksCache<TKey, TResult>
 	{
+		public TimeSpan? Expiration { get; set; } = null;
 		private Dictionary<TKey, Task<TResult>> _cachedTasks = new Dictionary<TKey, Task<TResult>>();
 
+		// I preferred to use two dictionaries in place of a dictionary of composed values (Result, DateTime)
+		// in order to avoid more indirections on resolution when Expiration == null
+		private Dictionary<TKey, DateTime> _setDates = new Dictionary<TKey, DateTime>();
+
+		private bool IsKeyExpired(TKey key)
+		{
+			DateTime setDate;
+			return Expiration.HasValue && _setDates.TryGetValue(key, out setDate) && setDate.Add(Expiration.Value) < DateTime.Now;
+		}
+
 		public Task<TResult> Set(TKey key, Task<TResult> task)
-			=> _cachedTasks[key] = task;
+		{
+			_cachedTasks[key] = task;
+			_setDates[key] = DateTime.Now;
+			return task;
+		}
 
 		public Task<TResult> Set(TKey key, TResult value)
-			=> _cachedTasks[key] = Task.FromResult(value);
+			=> Set(key, Task.FromResult(value));
 
 		public Task<TResult> Get(TKey key, Func<Task<TResult>> fallback)
 		{
 			Task<TResult> cached;
-			if (!_cachedTasks.TryGetValue(key, out cached))
+			if (!_cachedTasks.TryGetValue(key, out cached) || IsKeyExpired(key))
 			{
 				cached = Set(key, fallback());
 			}
@@ -35,13 +50,21 @@ namespace MakingSense.AspNet.HypermediaApi.Utilities
 			=> Get(key, () => Task.FromResult(fallback(key)));
 
 		public void Remove(TKey key)
-			=> _cachedTasks.Remove(key);
+		{
+			_cachedTasks.Remove(key);
+			_setDates.Remove(key);
+		}
 
 		public void Clear()
-			=> _cachedTasks.Clear();
+		{
+			_cachedTasks.Clear();
+			_setDates.Clear();
+		}
 
 		public bool Contains(TKey key)
-			=> _cachedTasks.ContainsKey(key);
+		{
+			return _cachedTasks.ContainsKey(key) && !IsKeyExpired(key);
+		}
 	}
 
 	public class QueryTasksCache<T1, T2, TResult> : QueryTasksCache<Tuple<T1, T2>, TResult>

--- a/src/MakingSense.AspNet.HypermediaApi/Utilities/QueryTaskCache.cs
+++ b/src/MakingSense.AspNet.HypermediaApi/Utilities/QueryTaskCache.cs
@@ -67,6 +67,30 @@ namespace MakingSense.AspNet.HypermediaApi.Utilities
 		}
 	}
 
+	public class QueryTaskCache<TResult>
+	{
+		const byte key = default(byte);
+		private readonly QueryTasksCache<byte, TResult> inner = new QueryTasksCache<byte, TResult>();
+
+		public TimeSpan? Expiration
+		{
+			get { return inner.Expiration; }
+			set { inner.Expiration = value; }
+		}
+
+		public Task<TResult> Set(Task<TResult> task) => inner.Set(key, task);
+
+		public Task<TResult> Set(TResult value) => inner.Set(key, value);
+
+		public Task<TResult> Get(Func<Task<TResult>> fallback) => inner.Get(key, fallback);
+
+		public Task<TResult> Get(Func<TResult> fallback) => inner.Get(key, fallback);
+
+		public void Clear() => inner.Clear();
+
+		public bool HasValue() => inner.Contains(key);
+	}
+
 	public class QueryTasksCache<T1, T2, TResult> : QueryTasksCache<Tuple<T1, T2>, TResult>
 	{
 		public Task<TResult> Set(T1 key1, T2 key2, Task<TResult> task)


### PR DESCRIPTION
Hi @jwaimann and @abriscioli,

In some cases I need that persist for more time than a request, for example for Doppler Time Zone values, I think that it could be useful to create a static field for it:

```csharp
	public class CampaignShipping_To_DtoScheduling : IApiMapper<CampaignShipping, DtoScheduling>
	{
		private static QueryTaskCache<UserTimeZones> _timeZonesCache 
			= new QueryTasksCache<UserTimeZones>() { Expiration = TimeSpan.FromMinutes(30) };

		public void Fill(CampaignShipping input, DtoScheduling output)
		{
			var timeZones = _timeZonesCache.Get(() =>
			    timeZoneService.Get());

			output.IdGMTSelected = timeZones.GetByOffset(input.scheduledDate)

			// . . . 
```

Could you review?
