### PR TITLE
Rename `message` as `message-result`

### DIFF
--- a/src/MakingSense.AspNet.HypermediaApi/Model/CreationResult.cs
+++ b/src/MakingSense.AspNet.HypermediaApi/Model/CreationResult.cs
@@ -12,7 +12,7 @@ using Microsoft.Net.Http.Headers;
 namespace MakingSense.AspNet.HypermediaApi.Model
 {
 	[Schema(typeof(CreationResult))]
-	public class CreationResult : MessageModel, IActionResult
+	public class CreationResult : MessageResult, IActionResult
 	{
 		private Maybe<Link> _creationLink;
 		private int _statusCode;

--- a/src/MakingSense.AspNet.HypermediaApi/Model/MessageResult.cs
+++ b/src/MakingSense.AspNet.HypermediaApi/Model/MessageResult.cs
@@ -6,8 +6,8 @@ using System.ComponentModel.DataAnnotations;
 namespace MakingSense.AspNet.HypermediaApi.Model
 {
 	//TODO support [Schema] (without parameter)
-	[Schema(typeof(MessageModel))]
-	public class MessageModel : BaseModel
+	[Schema(typeof(MessageResult))]
+	public class MessageResult : BaseModel
 	{
 		[JsonProperty(NullValueHandling = NullValueHandling.Ignore, Required = Required.Always)]
 		[Required]


### PR DESCRIPTION
Hi @abriscioli, @jwaiman, @pbarrios, @afantini and @easla,

Since there are name collisions in _Relay_ I decided, after some conversations, to rename `message` as `message-result`.

If you do not like the name, try to make some consensus and let me know what name should I use.