### PR TITLE
DR-279 - Allow to override headers on Problem.AddHeader()

### DIFF
--- a/src/MakingSense.AspNet.HypermediaApi/ExceptionHandling/Problem.cs
+++ b/src/MakingSense.AspNet.HypermediaApi/ExceptionHandling/Problem.cs
@@ -19,7 +19,7 @@ namespace MakingSense.AspNet.HypermediaApi.ExceptionHandling
 			$"{Path}{status}.{errorCode}-{title.ToLower().Replace(", ", "").Replace(" ", "-")}";
 
 		public void AddHeader(string header, string value) =>
-			_customHeaders.Add(header, value);
+			_customHeaders[header] = value;
 
 		public IEnumerable<KeyValuePair<string, string>> GetCustomHeaders() =>
 			_customHeaders.AsEnumerable();

--- a/src/MakingSense.AspNet.HypermediaApi/Problems/AuthenticationProblem.cs
+++ b/src/MakingSense.AspNet.HypermediaApi/Problems/AuthenticationProblem.cs
@@ -9,7 +9,7 @@ namespace MakingSense.AspNet.HypermediaApi.Problems
 
 		public AuthenticationProblem()
 		{
-			this.AddHeader("WWW-Authenticate", "Bearer");
+			AddHeader("WWW-Authenticate", "Bearer");
 		}
 	}
 }


### PR DESCRIPTION
@MakingSense/doppler-relay, this change is required to allow to override headers on problems in order to allow me to return an special header for expired tokens according to [RFC 6750](https://tools.ietf.org/html/rfc6750#section-3.1):

```
WWW-Authenticate: Bearer error="invalid_token" error_description="The access token expired"
```

In place of

```
WWW-Authenticate: Bearer
```

Could you review?