### PR TITLE
Reword single page link

### DIFF
--- a/src/MakingSense.AspNet.HypermediaApi/Linking/ModelLinkingExtensions.cs
+++ b/src/MakingSense.AspNet.HypermediaApi/Linking/ModelLinkingExtensions.cs
@@ -147,7 +147,7 @@ namespace MakingSense.AspNet.HypermediaApi.Linking
 		{
 			if (link.Relation.Contains<FirstRelation>() && link.Relation.Contains<LastRelation>())
 			{
-				link.SetDescription("Single page");
+				link.SetDescription("Current page (single)");
 			}
 			else if (link.Relation.Contains<SelfRelation>() && currentPage > lastPage)
 			{


### PR DESCRIPTION
Hi @sliovino and @nreal, it changes current page (self) link description when there is only a result page.

I have to also update the reference in Relay API project.

