### PR TITLE
Extract AggregateException messages

### DIFF
--- a/src/MakingSense.AspNetCore.HypermediaApi/ExceptionHandling/DefaultProblemDetectionHandler.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/ExceptionHandling/DefaultProblemDetectionHandler.cs
@@ -18,6 +18,11 @@ namespace MakingSense.AspNetCore.HypermediaApi.ExceptionHandling
 
 		public Problem ExtractProblem(Exception exception)
 		{
+			if (exception is AggregateException aggregateException && aggregateException.InnerExceptions.Count == 1)
+			{
+				exception = aggregateException.InnerException;
+			}
+
 			if (exception is ApiException apiException)
 			{
 				return apiException.Problem;

--- a/src/MakingSense.AspNetCore.HypermediaApi/ExceptionHandling/DefaultProblemDetectionHandler.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/ExceptionHandling/DefaultProblemDetectionHandler.cs
@@ -18,14 +18,12 @@ namespace MakingSense.AspNetCore.HypermediaApi.ExceptionHandling
 
 		public Problem ExtractProblem(Exception exception)
 		{
-			var apiException = exception as ApiException;
-			if (apiException != null)
+			if (exception is ApiException apiException)
 			{
 				return apiException.Problem;
 			}
 
-			var authException = exception as AuthenticationException;
-			if (authException != null)
+			if (exception is AuthenticationException authException)
 			{
 				return new AuthenticationErrorProblem(exception.Message);
 			}

--- a/src/MakingSense.AspNetCore.HypermediaApi/Problems/UnexpectedProblem.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/Problems/UnexpectedProblem.cs
@@ -13,7 +13,7 @@ namespace MakingSense.AspNetCore.HypermediaApi.Problems
 
 		public UnexpectedProblem(Exception exception)
 		{
-			detail = $"An unexpected error was thrown/r/n Exception Message: {exception.Message} /r/n Exception Type: {exception.GetType()}";
+			detail = $"An unexpected error was thrown\r\n\tException Message: {exception.Message} \r\n\tException Type: {exception.GetType()}";
 		}
 	}
 }

--- a/src/MakingSense.AspNetCore.HypermediaApi/Problems/UnexpectedProblem.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/Problems/UnexpectedProblem.cs
@@ -1,6 +1,7 @@
 ﻿using MakingSense.AspNetCore.HypermediaApi.ExceptionHandling;
 using Microsoft.AspNetCore.Http;
 using System;
+using System.Linq;
 
 namespace MakingSense.AspNetCore.HypermediaApi.Problems
 {
@@ -13,7 +14,18 @@ namespace MakingSense.AspNetCore.HypermediaApi.Problems
 
 		public UnexpectedProblem(Exception exception)
 		{
-			detail = $"An unexpected error was thrown\r\n\tException Message: {exception.Message} \r\n\tException Type: {exception.GetType()}";
+			if (exception is AggregateException aggregateException)
+			{
+				detail = "An unexpected error was thrown"
+					+ string.Join("", aggregateException.Flatten().InnerExceptions.Select(RenderException));
+			}
+			else
+			{
+				detail = "An unexpected error was thrown" + RenderException(exception);
+			}
 		}
+
+		private string RenderException(Exception exception) =>
+			$"\r\n\tException Message: {exception.Message} \r\n\tException Type: {exception.GetType()}";
 	}
 }

--- a/src/MakingSense.AspNetCore.HypermediaApi/Problems/UnexpectedProblem.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/Problems/UnexpectedProblem.cs
@@ -6,15 +6,14 @@ namespace MakingSense.AspNetCore.HypermediaApi.Problems
 {
 	public class UnexpectedProblem : Problem
 	{
-		private Exception _exception;
 		public override string title => "Unexpected error";
 		public override int status => StatusCodes.Status500InternalServerError;
 		public override int errorCode => 0;
-		public override string detail => $"An unexpected error was thrown/r/n Exception Message: {_exception.Message} /r/n Exception Type: {_exception.GetType()}";
+		public override string detail { get; }
 
 		public UnexpectedProblem(Exception exception)
 		{
-			_exception = exception;
+			detail = $"An unexpected error was thrown/r/n Exception Message: {exception.Message} /r/n Exception Type: {exception.GetType()}";
 		}
 	}
 }


### PR DESCRIPTION
Hi @javierburger, @mmosquera and @miguel-rodriguez-cimino,

It should improve error messages when the unexpected exception is an AggregateException. I am not sure about the last commit (0c8a79abdfd449b26ae3624258fd94b5296d5eff). What do you think?

I think that it will be useful to understand the current issue, so do you agree on including it in the release?