### PR TITLE
Fix warning

### DIFF
--- a/src/MakingSense.AspNetCore.HypermediaApi/ApiMappers/ApiMapperExtensions.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/ApiMappers/ApiMapperExtensions.cs
@@ -59,18 +59,16 @@ namespace MakingSense.AspNetCore.HypermediaApi.ApiMappers
 		public static IEnumerable<TOut> Map<TIn, TOut>(this IApiMapper<TIn, TOut> mapper, IEnumerable<TIn> inputEnumerable)
 			where TOut : class, new()
 		{
-			var queryableProyector = mapper as IQueryableMapper<TIn, TOut>;
 			return
-				queryableProyector != null ? queryableProyector.Map(inputEnumerable.AsQueryable())
+				mapper is IQueryableMapper<TIn, TOut> queryableProyector ? queryableProyector.Map(inputEnumerable.AsQueryable())
 				: inputEnumerable.Select(x => mapper.Map(x));
 		}
 
 		public static IEnumerable<TOut> Map<TIn, TOut>(this IApiMapper<TIn, TOut> mapper, IQueryable<TIn> inputQueryable)
 			where TOut : class, new()
 		{
-			var queryableProyector = mapper as IQueryableMapper<TIn, TOut>;
 			return
-				queryableProyector != null ? queryableProyector.Map(inputQueryable)
+				mapper is IQueryableMapper<TIn, TOut> queryableProyector ? queryableProyector.Map(inputQueryable)
 				: inputQueryable.AsEnumerable().Select(x => mapper.Map(x));
 		}
 

--- a/src/MakingSense.AspNetCore.HypermediaApi/Formatters/HypermediaApiJsonInputFormatter.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/Formatters/HypermediaApiJsonInputFormatter.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Buffers;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ObjectPool;
@@ -17,8 +15,24 @@ namespace MakingSense.AspNetCore.HypermediaApi.Formatters
 
 		public bool AcceptAnyContentType { get; set; } = false;
 
+		[Obsolete("This constructor is obsolete and will be removed in a future version.")]
 		public HypermediaApiJsonInputFormatter(ILogger logger, JsonSerializerSettings serializerSettings, ArrayPool<char> charPool, ObjectPoolProvider objectPoolProvider)
 			: base(logger, serializerSettings, charPool, objectPoolProvider)
+		{
+			//TODO: add a setting to strict case sensitive de-serialization for properties
+
+			SupportedMediaTypes.Clear();
+			SupportedMediaTypes.Add("application/json");
+			SupportedMediaTypes.Add("application/javascript");
+			SupportedMediaTypes.Add("text/json");
+			SupportedMediaTypes.Add("text/javascript");
+			SupportedMediaTypes.Add("application/x-javascript");
+			SupportedMediaTypes.Add("text/x-javascript");
+			SupportedMediaTypes.Add("text/x-json");
+		}
+
+		public HypermediaApiJsonInputFormatter(ILogger logger, JsonSerializerSettings serializerSettings, ArrayPool<char> charPool, ObjectPoolProvider objectPoolProvider, MvcOptions options, MvcJsonOptions jsonOptions)
+			: base(logger, serializerSettings, charPool, objectPoolProvider, options, jsonOptions)
 		{
 			//TODO: add a setting to strict case sensitive de-serialization for properties
 

--- a/src/MakingSense.AspNetCore.HypermediaApi/Formatters/HypermediaApiJsonInputFormatter.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/Formatters/HypermediaApiJsonInputFormatter.cs
@@ -17,18 +17,8 @@ namespace MakingSense.AspNetCore.HypermediaApi.Formatters
 
 		[Obsolete("This constructor is obsolete and will be removed in a future version.")]
 		public HypermediaApiJsonInputFormatter(ILogger logger, JsonSerializerSettings serializerSettings, ArrayPool<char> charPool, ObjectPoolProvider objectPoolProvider)
-			: base(logger, serializerSettings, charPool, objectPoolProvider)
+			: this(logger, serializerSettings, charPool, objectPoolProvider, null, null)
 		{
-			//TODO: add a setting to strict case sensitive de-serialization for properties
-
-			SupportedMediaTypes.Clear();
-			SupportedMediaTypes.Add("application/json");
-			SupportedMediaTypes.Add("application/javascript");
-			SupportedMediaTypes.Add("text/json");
-			SupportedMediaTypes.Add("text/javascript");
-			SupportedMediaTypes.Add("application/x-javascript");
-			SupportedMediaTypes.Add("text/x-javascript");
-			SupportedMediaTypes.Add("text/x-json");
 		}
 
 		public HypermediaApiJsonInputFormatter(ILogger logger, JsonSerializerSettings serializerSettings, ArrayPool<char> charPool, ObjectPoolProvider objectPoolProvider, MvcOptions options, MvcJsonOptions jsonOptions)

--- a/src/MakingSense.AspNetCore.HypermediaApi/Formatters/Internal/HypermediaApiMvcOptionsSetup.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/Formatters/Internal/HypermediaApiMvcOptionsSetup.cs
@@ -18,46 +18,22 @@ namespace MakingSense.AspNetCore.HypermediaApi.Formatters.Internal
 			ObjectPoolProvider objectPoolProvider)
 			: base((options) => ConfigureMvc(
 				options,
-				jsonOptions.Value,
+				jsonOptions.Value.SerializerSettings,
 				loggerFactory,
 				charPool,
-				objectPoolProvider))
+				objectPoolProvider,
+				jsonOptions.Value))
 		{
 		}
 
-		[Obsolete("This method is obsolete and will be removed in a future version.")]
 		public static void ConfigureMvc(
 			MvcOptions options,
 			JsonSerializerSettings serializerSettings,
 			ILoggerFactory loggerFactory,
 			ArrayPool<char> charPool,
-			ObjectPoolProvider objectPoolProvider)
+			ObjectPoolProvider objectPoolProvider,
+			MvcJsonOptions jsonOptions = null)
 		{
-			serializerSettings.Formatting = Formatting.Indented;
-
-			serializerSettings.Converters.Add(new DateTimeOffsetFormatJsonConverter());
-			serializerSettings.DateParseHandling = DateParseHandling.None;
-
-			options.OutputFormatters.Clear();
-			options.OutputFormatters.Add(new JsonOutputFormatter(serializerSettings, charPool));
-
-			options.InputFormatters.Clear();
-			var jsonInputLogger = loggerFactory.CreateLogger<HypermediaApiJsonInputFormatter>();
-			options.InputFormatters.Add(new HypermediaApiJsonInputFormatter(
-				jsonInputLogger,
-				serializerSettings,
-				charPool,
-				objectPoolProvider));
-		}
-
-		public static void ConfigureMvc(
-			MvcOptions options,
-			MvcJsonOptions jsonOptions,
-			ILoggerFactory loggerFactory,
-			ArrayPool<char> charPool,
-			ObjectPoolProvider objectPoolProvider)
-		{
-			JsonSerializerSettings serializerSettings = jsonOptions.SerializerSettings;
 			serializerSettings.Formatting = Formatting.Indented;
 
 			serializerSettings.Converters.Add(new DateTimeOffsetFormatJsonConverter());

--- a/src/MakingSense.AspNetCore.HypermediaApi/Linking/BaseLinkHelper.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/Linking/BaseLinkHelper.cs
@@ -67,10 +67,9 @@ namespace MakingSense.AspNetCore.HypermediaApi.Linking
 			var wrappedValues = Enumerable.Range(0, arguments.Count).Select(x =>
 			{
 				var argument = arguments[x];
-				var unaryExpression = argument as UnaryExpression;
 				TemplateParameter value;
 
-				if (unaryExpression != null && unaryExpression.Operand.Type.GetTypeInfo().IsSubclassOf(typeof(TemplateParameter)))
+				if (argument is UnaryExpression unaryExpression && unaryExpression.Operand.Type.GetTypeInfo().IsSubclassOf(typeof(TemplateParameter)))
 				{
 					value = Expression.Lambda(unaryExpression.Operand).Compile().DynamicInvoke() as TemplateParameter;
 				}

--- a/src/MakingSense.AspNetCore.HypermediaApi/ValidationFilters/RequiredPayloadFilter.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/ValidationFilters/RequiredPayloadFilter.cs
@@ -22,8 +22,7 @@ namespace MakingSense.AspNetCore.HypermediaApi.ValidationFilters
 		{
 			if (context.ModelState.IsValid)
 			{
-				var actionDescriptor = context.ActionDescriptor as ControllerActionDescriptor;
-				if (actionDescriptor == null)
+				if (!(context.ActionDescriptor is ControllerActionDescriptor actionDescriptor))
 				{
 					return;
 				}


### PR DESCRIPTION
Must be merged after #31 
Suggest merge after #33 

`public JsonInputFormatter(ILogger logger, JsonSerializerSettings serializerSettings, ArrayPool<char> charPool, ObjectPoolProvider objectPoolProvider)`

is obsolete and will be remove in the future, this change adapt our code to use the new constructor.

Add a new method with the expected parameter and mark the original as Obsolete for blackguard compatibility