### PR TITLE
Update AspNetCore to 3.x

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 os: Visual Studio 2017
 
-version: 2.2.0-alpha-{build}
+version: 2.2.1-alpha-{build}
 
 nuget:
   project_feed: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-os: Visual Studio 2017
+os: Visual Studio 2019
 
 version: 2.2.1-alpha-{build}
 

--- a/src/MakingSense.AspNetCore.HypermediaApi/Formatters/HypermediaApiJsonInputFormatter.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/Formatters/HypermediaApiJsonInputFormatter.cs
@@ -6,6 +6,11 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ObjectPool;
 using Newtonsoft.Json;
 
+#if NETCOREAPP3_0 || NETCOREAPP3_1
+using MvcJsonOptions = Microsoft.AspNetCore.Mvc.MvcNewtonsoftJsonOptions;
+using JsonInputFormatter = Microsoft.AspNetCore.Mvc.Formatters.NewtonsoftJsonInputFormatter;
+#endif
+
 namespace MakingSense.AspNetCore.HypermediaApi.Formatters
 {
 	// TODO: it is difficult to personalize it. Find an alternative.

--- a/src/MakingSense.AspNetCore.HypermediaApi/Formatters/Internal/HypermediaApiMvcOptionsSetup.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/Formatters/Internal/HypermediaApiMvcOptionsSetup.cs
@@ -7,6 +7,10 @@ using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
+#if NETCOREAPP3_0 || NETCOREAPP3_1
+using MvcJsonOptions = Microsoft.AspNetCore.Mvc.MvcNewtonsoftJsonOptions;
+#endif
+
 namespace MakingSense.AspNetCore.HypermediaApi.Formatters.Internal
 {
 	public class HypermediaApiMvcOptionsSetup : ConfigureOptions<MvcOptions>
@@ -40,7 +44,17 @@ namespace MakingSense.AspNetCore.HypermediaApi.Formatters.Internal
 			serializerSettings.DateParseHandling = DateParseHandling.None;
 
 			options.OutputFormatters.Clear();
-			options.OutputFormatters.Add(new JsonOutputFormatter(serializerSettings, charPool));
+
+			var jsonOutputFormatter =
+#if NETCOREAPP3_0 || NETCOREAPP3_1
+				new NewtonsoftJsonOutputFormatter(serializerSettings, charPool, options);
+#elif NETSTANDARD2_0
+				new JsonOutputFormatter(serializerSettings, charPool);
+#else
+#error unknown target framework
+#endif
+
+			options.OutputFormatters.Add(jsonOutputFormatter);
 
 			options.InputFormatters.Clear();
 			var jsonInputLogger = loggerFactory.CreateLogger<HypermediaApiJsonInputFormatter>();

--- a/src/MakingSense.AspNetCore.HypermediaApi/MakingSense.AspNetCore.HypermediaApi.csproj
+++ b/src/MakingSense.AspNetCore.HypermediaApi/MakingSense.AspNetCore.HypermediaApi.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>MakingSense.AspNetCore.HypermediaApi Class Library</Description>
     <Authors>MakingSense</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+	<TargetFrameworks>netcoreapp3.1;netcoreapp3.0;netstandard2.0</TargetFrameworks>
     <AssemblyName>MakingSense.AspNetCore.HypermediaApi</AssemblyName>
     <PackageId>MakingSense.AspNetCore.HypermediaApi</PackageId>
     <PackageTags>ASP.NET 5;vnext;Hypermedia;API;REST;ASP.NET Core</PackageTags>
@@ -18,10 +18,26 @@
     <ProjectReference Include="..\MakingSense.AspNetCore.Abstractions\MakingSense.AspNetCore.Abstractions.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson">
+      <Version>3.1.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson">
+      <Version>3.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageReference Include="System.Threading" Version="4.3.0" />

--- a/src/MakingSense.AspNetCore.HypermediaApi/MakingSense.AspNetCore.HypermediaApi.csproj
+++ b/src/MakingSense.AspNetCore.HypermediaApi/MakingSense.AspNetCore.HypermediaApi.csproj
@@ -11,7 +11,7 @@
     <PackageLicenseUrl>http://www.gnu.org/licenses/lgpl.html</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/MakingSense/aspnet-hypermedia-api</RepositoryUrl>
-    <VersionPrefix>2.2.0-alpha</VersionPrefix>
+    <VersionPrefix>2.2.1-alpha</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR is for add support for new version of AspNetCore 3.0 and 3.1 that have some changes about JsonFormatter and need use multi target project

See [migrate-libraries-via-multi-targeting](https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-3.1&tabs=visual-studio#migrate-libraries-via-multi-targeting) for more info

Related to: DM-230