### PR TITLE
Use tag for generate nuget version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,25 @@ os: Visual Studio 2019
 
 version: 2.2.1-alpha-{build}
 
+init:
+  - ps: >-
+      if ($env:APPVEYOR_REPO_TAG -eq "true")
+
+      {
+          Update-AppveyorBuild -Version $($env:APPVEYOR_REPO_TAG_NAME.TrimStart('v'))
+      }
+
+dotnet_csproj:
+  patch: true
+  file: '**\*.csproj'
+  version: "{version}"
+  package_version: "{version}"
+  assembly_version: "{version}"
+  file_version: "{version}"
+  informational_version: "{version}"
+
 nuget:
+  account_feed: true
   project_feed: true
 
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,20 +6,10 @@ nuget:
   project_feed: true
 
 before_build:
- - cmd: set DOTNET_ASSEMBLY_FILE_VERSION=%APPVEYOR_BUILD_NUMBER%
- - cmd: set DOTNET_BUILD_VERSION=%APPVEYOR_BUILD_NUMBER%
  - ps: dotnet restore
 
 artifacts:
  - path: '**\*.nupkg'
-
-build_script:
- - cmd: dotnet build src/MakingSense.AspNetCore.Abstractions --version-suffix %APPVEYOR_BUILD_NUMBER%
- - cmd: dotnet build src/MakingSense.AspNetCore.HypermediaApi --version-suffix %APPVEYOR_BUILD_NUMBER%
-
-after_build:
- - cmd: dotnet pack src/MakingSense.AspNetCore.Abstractions --version-suffix %APPVEYOR_BUILD_NUMBER%
- - cmd: dotnet pack src/MakingSense.AspNetCore.HypermediaApi --version-suffix %APPVEYOR_BUILD_NUMBER%
 
 notifications:
  - provider: Slack

--- a/src/MakingSense.AspNetCore.Abstractions/MakingSense.AspNetCore.Abstractions.csproj
+++ b/src/MakingSense.AspNetCore.Abstractions/MakingSense.AspNetCore.Abstractions.csproj
@@ -12,6 +12,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/MakingSense/aspnet-hypermedia-api</RepositoryUrl>
     <VersionPrefix>2.2.0-alpha</VersionPrefix>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MakingSense.AspNetCore.Abstractions/MakingSense.AspNetCore.Abstractions.csproj
+++ b/src/MakingSense.AspNetCore.Abstractions/MakingSense.AspNetCore.Abstractions.csproj
@@ -11,7 +11,7 @@
     <PackageLicenseUrl>http://www.gnu.org/licenses/lgpl.html</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/MakingSense/aspnet-hypermedia-api</RepositoryUrl>
-    <VersionPrefix>2.2.0-alpha</VersionPrefix>
+    <Version>2.2.0-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/MakingSense.AspNetCore.HypermediaApi/MakingSense.AspNetCore.HypermediaApi.csproj
+++ b/src/MakingSense.AspNetCore.HypermediaApi/MakingSense.AspNetCore.HypermediaApi.csproj
@@ -11,7 +11,7 @@
     <PackageLicenseUrl>http://www.gnu.org/licenses/lgpl.html</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/MakingSense/aspnet-hypermedia-api</RepositoryUrl>
-    <VersionPrefix>2.2.1-alpha</VersionPrefix>
+    <Version>2.2.1-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/MakingSense.AspNetCore.HypermediaApi/MakingSense.AspNetCore.HypermediaApi.csproj
+++ b/src/MakingSense.AspNetCore.HypermediaApi/MakingSense.AspNetCore.HypermediaApi.csproj
@@ -12,6 +12,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/MakingSense/aspnet-hypermedia-api</RepositoryUrl>
     <VersionPrefix>2.2.1-alpha</VersionPrefix>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is for use tag for version nugets instead of use a fix versioning.

Similar approach used for generate MailerQ nuget