### PR TITLE
Fix version conflicts caused by PR#45

### DIFF
--- a/src/MakingSense.AspNetCore.HypermediaApi/MakingSense.AspNetCore.HypermediaApi.csproj
+++ b/src/MakingSense.AspNetCore.HypermediaApi/MakingSense.AspNetCore.HypermediaApi.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>MakingSense.AspNetCore.HypermediaApi Class Library</Description>
     <Authors>MakingSense</Authors>
-	<TargetFrameworks>netcoreapp3.1;netcoreapp3.0;netstandard2.0</TargetFrameworks>
+	<TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp3.0;netstandard2.0</TargetFrameworks>
     <AssemblyName>MakingSense.AspNetCore.HypermediaApi</AssemblyName>
     <PackageId>MakingSense.AspNetCore.HypermediaApi</PackageId>
     <PackageTags>ASP.NET 5;vnext;Hypermedia;API;REST;ASP.NET Core</PackageTags>
@@ -18,6 +18,13 @@
   <ItemGroup>
     <ProjectReference Include="..\MakingSense.AspNetCore.Abstractions\MakingSense.AspNetCore.Abstractions.csproj" />
   </ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson">
+			<Version>5.0.3</Version>
+		</PackageReference>
+	</ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.AspNetCore.Mvc.NewtonsoftJson from 3.1.0 to 5.0.3. [(PR#45)](https://github.com/MakingSense/aspnet-hypermedia-api/pull/45).
Hope this fix can help you.

Best regards,
sucrose