### PR TITLE
DSL-612 - Quoted Profile

### DIFF
--- a/src/MakingSense.AspNetCore.HypermediaApi/Metadata/ActionRelationAttribute.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/Metadata/ActionRelationAttribute.cs
@@ -98,9 +98,11 @@ namespace MakingSense.AspNetCore.HypermediaApi.Metadata
 			}
 		}
 
-		private static void AddProfileToContentType(ResultExecutingContext context, SchemaAttribute schemaAttribute)
+		private static void AddProfileToContentType(ResultExecutingContext context, SchemaAttribute schemaAttribute, bool keepUnquoted = false)
 		{
-			context.HttpContext.Response.ContentType += $"; profile={schemaAttribute.SchemaFilePath}";
+			var profile = keepUnquoted ? schemaAttribute.SchemaFilePath
+				: $"\"{schemaAttribute.SchemaFilePath?.Replace("\"", "\\\"")}\"";
+			context.HttpContext.Response.ContentType += $"; profile={profile}";
 		}
 
 		private SchemaAttribute GetSchemaAttributeFromOutputModel()

--- a/src/MakingSense.AspNetCore.HypermediaApi/Metadata/ActionRelationAttribute.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/Metadata/ActionRelationAttribute.cs
@@ -90,9 +90,11 @@ namespace MakingSense.AspNetCore.HypermediaApi.Metadata
 
 			if (schemaAttribute != null)
 			{
+				var keepUnquoted = context.HttpContext.Request.Query.ContainsKey("keep-unquoted-profile");
+
 				context.HttpContext.Response.OnStarting((o) =>
 				{
-					AddProfileToContentType(context, schemaAttribute);
+					AddProfileToContentType(context, schemaAttribute, keepUnquoted);
 					return Task.FromResult(0);
 				}, null);
 			}

--- a/src/MakingSense.AspNetCore.HypermediaApi/Metadata/ActionRelationAttribute.cs
+++ b/src/MakingSense.AspNetCore.HypermediaApi/Metadata/ActionRelationAttribute.cs
@@ -92,10 +92,15 @@ namespace MakingSense.AspNetCore.HypermediaApi.Metadata
 			{
 				context.HttpContext.Response.OnStarting((o) =>
 				{
-					context.HttpContext.Response.ContentType += $"; profile={schemaAttribute.SchemaFilePath}";
+					AddProfileToContentType(context, schemaAttribute);
 					return Task.FromResult(0);
 				}, null);
 			}
+		}
+
+		private static void AddProfileToContentType(ResultExecutingContext context, SchemaAttribute schemaAttribute)
+		{
+			context.HttpContext.Response.ContentType += $"; profile={schemaAttribute.SchemaFilePath}";
 		}
 
 		private SchemaAttribute GetSchemaAttributeFromOutputModel()


### PR DESCRIPTION
A client informed us that the RFC 2616 standard was not being complied with in the API responses.
We update the response so that the profile returns with quoted values.